### PR TITLE
Implemented Format for bool

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -10,6 +10,25 @@ pub trait Format: Sized + Default {
     fn from_mpv<F: Fn(*mut c_void) -> Result<()>>(fun: F) -> Result<Self>;
 }
 
+// MPV_FORMAT_FLAG
+impl Format for bool {
+    const MPV_FORMAT: i32 = 3;
+
+    fn from_ptr(ptr: *const c_void) -> Result<Self> {
+        Ok(unsafe { *(ptr as *const Self) })
+    }
+
+    fn to_mpv<F: Fn(*const c_void) -> Result<()>>(self, fun: F) -> Result<()> {
+        fun(&self as *const _ as *const c_void)
+    }
+
+    fn from_mpv<F: Fn(*mut c_void) -> Result<()>>(fun: F) -> Result<Self> {
+        let mut data = Self::default();
+        fun(&mut data as *mut _ as *mut c_void)?;
+        Ok(data)
+    }
+}
+
 impl Format for f64 {
     const MPV_FORMAT: i32 = 5;
 


### PR DESCRIPTION
Implemented Format trait for use in properties with MPV_FORMAT_FLAG.

*I am surprised it wasn't there in the first place*